### PR TITLE
Adds a list of language "tags" in the changelist view

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,37 @@ To use, install it into your project using pip::
     pip install aldryn-translation-tools
 
 
+admin.AllTranslationsMixin
+--------------------------
+
+Automatically adds a list of language "tags" in the changelist. Tag color
+indicates the state of translation for that object. Grey meaning untranslated,
+blue meaning translated. Darker versions of each are used to indicate the
+current language.
+
+Each tag is linked to the specific language tag on the change form of the
+object.
+
+A similar capability is in HVAD, and now there is this for Parler-based
+projects.
+
+Preview:
+
+.. image:: https://cloud.githubusercontent.com/assets/615759/7727430/5889f0e0-ff11-11e4-930a-2bfc80bef426.jpg
+
+To use this, merely import and add the mixin to your Model Admin class: ::
+
+    from parler.admin import TranslatableAdmin
+    from aldryn_translation_tools.admin import AllTranslationsMixin
+
+    class GroupAdmin(AllTranslationsMixin, TranslatableAdmin):
+       # ....
+
+If you wish to put the tags into a different column, you can add
+`all_translations` to the list_display list wherever you'd like, otherwise the
+"Languages" column will automatically be placed on the far right.
+
+
 models.TranslationHelperMixin
 -----------------------------
 

--- a/aldryn_translation_tools/admin.py
+++ b/aldryn_translation_tools/admin.py
@@ -25,8 +25,9 @@ class AllTranslationsMixin(object):
         available = list(obj.get_available_languages())
         current = get_current_language()
         langs = []
-        for code, title in settings.LANGUAGES:
+        for code, lang_name in settings.LANGUAGES:
             classes = ["lang-code", ]
+            title = lang_name
             if code == current:
                 classes += ["current", ]
             if code in available:

--- a/aldryn_translation_tools/admin.py
+++ b/aldryn_translation_tools/admin.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.conf import settings
+
+from cms.utils.i18n import get_current_language
+from cms.utils.urlutils import admin_reverse
+
+
+class AllTranslationsMixin(object):
+    class Media:
+        css = {'all': ('css/admin/all-translations-mixin.css', ), }
+
+    def all_translations(self, obj):
+        """
+        Adds a property to the list_display that lists all translations with
+        links directly to their change forms. Includes CSS to style the links to
+        looks like tags with color indicating current language, active and
+        inactive translations.
+
+        A similar capability is in HVAD, and now there is this for
+        Parler-based projects.
+        """
+        available = list(obj.get_available_languages())
+        current = get_current_language()
+        langs = []
+        for code, title in settings.LANGUAGES:
+            classes = ["lang-code", ]
+            if code == current:
+                classes += ["current", ]
+            if code in available:
+                classes += ["active", ]
+                title += " (translated)"
+            else:
+                title += " (untranslated)"
+            change_form_url = admin_reverse(
+                '{app_label}_{model_name}_change'.format(
+                    app_label=obj._meta.app_label.lower(),
+                    model_name=obj.__class__.__name__.lower(),
+                ), args=(obj.id, )
+            )
+            link = ('<a class="{classes}" href="{url}?language={code}" ' +
+                'title="{title}">{code}</a>').format(
+                classes=' '.join(classes),
+                url=change_form_url,
+                code=code,
+                title=title,
+            )
+            langs.append(link)
+        return ''.join(langs)
+    all_translations.short_description = 'Translations'
+    all_translations.allow_tags = True
+
+    def get_list_display(self, request):
+        """
+        Unless the the developer has already placed "all_translations" in the
+        list_display list (presumably specifically where she wants it), append
+        the list of translations to the end.
+        """
+        list_display = super(
+            AllTranslationsMixin, self).get_list_display(request)
+        if 'all_translations' not in list_display:
+            list_display = list(list_display) + ['all_translations', ]
+        return list_display

--- a/aldryn_translation_tools/static/css/admin/all-translations-mixin.css
+++ b/aldryn_translation_tools/static/css/admin/all-translations-mixin.css
@@ -1,23 +1,23 @@
 a.lang-code {
-  background-color: #BFBFBF; /* hsl(0, 0%, 75%); */
-  border-radius: 3px;
-  color: #fff !important;
-  display: inline-block;
-  font-size: 0.75em;
-  letter-spacing: 0.05em;
-  line-height: 1em;
-  margin-right: 0.25em;
-  padding: 3px;
-  text-decoration: none;
-  text-transform: uppercase;
+    background-color: #BFBFBF; /* hsl(0, 0%, 75%); */
+    border-radius: 3px;
+    color: #fff !important;
+    display: inline-block;
+    font-size: 0.75em;
+    letter-spacing: 0.05em;
+    line-height: 1em;
+    margin-right: 0.25em;
+    padding: 3px;
+    text-decoration: none;
+    text-transform: uppercase;
 }
 a.lang-code.active {
-  background-color: #3B99FC; /* hsl(211, 97%, 61%) */
+    background-color: #3B99FC; /* hsl(211, 97%, 61%) */
 }
 a.lang-code.current {
-  background-color: #999999; /* hsl(0, 0%, 60%); */
-  font-weight: bold;
+    background-color: #999999; /* hsl(0, 0%, 60%); */
+    font-weight: bold;
 }
 a.lang-code.current.active {
-  background-color: #3178BE; /* hsl(211, 59%, 48%) */
+    background-color: #3178BE; /* hsl(211, 59%, 48%) */
 }

--- a/aldryn_translation_tools/static/css/admin/all-translations-mixin.css
+++ b/aldryn_translation_tools/static/css/admin/all-translations-mixin.css
@@ -1,0 +1,23 @@
+a.lang-code {
+  background-color: #BFBFBF; /* hsl(0, 0%, 75%); */
+  border-radius: 3px;
+  color: #fff !important;
+  display: inline-block;
+  font-size: 0.75em;
+  letter-spacing: 0.05em;
+  line-height: 1em;
+  margin-right: 0.25em;
+  padding: 3px;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+a.lang-code.active {
+  background-color: #3B99FC; /* hsl(211, 97%, 61%) */
+}
+a.lang-code.current {
+  background-color: #999999; /* hsl(0, 0%, 60%); */
+  font-weight: bold;
+}
+a.lang-code.current.active {
+  background-color: #3178BE; /* hsl(211, 59%, 48%) */
+}


### PR DESCRIPTION
Adds a list of language "tags" in the changelist. Color indicates the state of translation for that object. Grey meaning untranslated, blue meaning translated. Darker versions of each are used to indicate the current language.

Each is linked to the change form of the object and the specific language clicked.

A similar capability is in HVAD, and now there is this for Parler-based projects.

Preview:
![all_translations](https://cloud.githubusercontent.com/assets/615759/7727430/5889f0e0-ff11-11e4-930a-2bfc80bef426.jpg)
