### PR TITLE
Adds LinkedRelatedInlineMixin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,19 @@ If you wish to put the tags into a different column, you can add
 "Languages" column will automatically be placed on the far right.
 
 
+admin.LinkedRelatedInlineMixin
+------------------------------
+
+This admin inline mixin links the first field to the row object's own admin
+change form.
+
+If the first field is editable, results are undefined but probably won't work
+as expected. For best results, consider making all fields readonly (since they
+can be edited with ease by following the link), and disabling the ability to
+add new objects by overriding has_add_permission() on the inline to always
+return ``False``.
+
+
 models.TranslationHelperMixin
 -----------------------------
 

--- a/aldryn_translation_tools/admin.py
+++ b/aldryn_translation_tools/admin.py
@@ -49,7 +49,7 @@ class LinkedRelatedInlineMixin(object):
         if len(self.original_fields):
             self.fields = ["reverse_link", ] + self.original_fields[1:]
         else:
-            self.fields = "reverse_link"
+            self.fields = ["reverse_link"]
         self.reverse_link = self.ReverseLink(self.original_fields[0])
         super(LinkedRelatedInlineMixin, self).__init__(
             parent_model, admin_site)
@@ -72,7 +72,7 @@ class LinkedRelatedInlineMixin(object):
         if fields:
             return list(fields)
         else:
-            return None
+            return []
 
     def get_readonly_fields(self, request, obj=None):
         readonly_fields = super(

--- a/aldryn_translation_tools/admin.py
+++ b/aldryn_translation_tools/admin.py
@@ -24,8 +24,12 @@ class LinkedRelatedInlineMixin(object):
     extra = 0
 
     class ReverseLink:
+
+        allow_tags = True
+
         def __init__(self, display_link="link"):
             self.display_link = display_link
+            self.short_description = display_link
 
         def __call__(self, obj):
             model_name = obj.__class__.__name__.lower()
@@ -39,14 +43,6 @@ class LinkedRelatedInlineMixin(object):
                 title=_('Click to view or edit this {0}').format(
                     obj._meta.verbose_name),
                 link=getattr(obj, self.display_link))
-
-        @property
-        def short_description(self):
-            return self.display_link
-
-        @property
-        def allow_tags(self):
-            return True
 
     def __init__(self, parent_model, admin_site):
         self.original_fields = self.get_fields_list(None)

--- a/aldryn_translation_tools/admin.py
+++ b/aldryn_translation_tools/admin.py
@@ -50,8 +50,7 @@ class LinkedRelatedInlineMixin(object):
             self.fields = ["reverse_link", ] + self.original_fields[1:]
         else:
             self.fields = "reverse_link"
-        self.reverse_link = LinkedRelatedInlineMixin.ReverseLink(
-            self.original_fields[0])
+        self.reverse_link = self.ReverseLink(self.original_fields[0])
         super(LinkedRelatedInlineMixin, self).__init__(
             parent_model, admin_site)
 


### PR DESCRIPTION
Provides a Mixin for Admin Inlines which links the first field to the natural change form for the object presented.
