### PR TITLE
Fix str != unicode issue, if source was type str (Model.objects.create)

### DIFF
--- a/aldryn_translation_tools/models.py
+++ b/aldryn_translation_tools/models.py
@@ -120,6 +120,7 @@ class TranslatedAutoSlugifyMixin(object):
             source = self.get_slug_source()
             language = self.get_current_language() or get_default_language()
             if source:
+                source = force_text(source)
                 ideal_slug = force_text(slugify(source))
             else:
                 # For some reason, the slug came back empty, use the default


### PR DESCRIPTION
If someone will create object using manager and will provide string values for fields we get an exception (events example):

```
Traceback (most recent call last):
  File "./aldryn_events/tests/test_utils.py", line 19, in test_build_calendar
    publish_at=tz_datetime(2015, 2, 10)
  File "./aldryn_events/tests/base.py", line 110, in create_event
    event = Event.objects.create(**en)
  File "/Users/Starky/projects/aldryn/aldryn-events/.tox/py27-dj17-cms31/lib/python2.7/site-packages/django/db/models/manager.py", line 92, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/Starky/projects/aldryn/aldryn-events/.tox/py27-dj17-cms31/lib/python2.7/site-packages/aldryn_apphooks_config/managers/parler.py", line 30, in create
    return super(TranslatableQuerySet, self).create(**kwargs)
  File "/Users/Starky/projects/aldryn/aldryn-events/.tox/py27-dj17-cms31/lib/python2.7/site-packages/django/db/models/query.py", line 372, in create
    obj.save(force_insert=True, using=self.db)
  File "/Users/Starky/projects/aldryn/aldryn-events/.tox/py27-dj17-cms31/lib/python2.7/site-packages/aldryn_translation_tools/models.py", line 123, in save
    ideal_slug = force_text(slugify(source))
  File "/Users/Starky/projects/aldryn/aldryn-events/.tox/py27-dj17-cms31/lib/python2.7/site-packages/django/utils/functional.py", line 214, in wrapper
    return func(*args, **kwargs)
  File "/Users/Starky/projects/aldryn/aldryn-events/.tox/py27-dj17-cms31/lib/python2.7/site-packages/django/utils/text.py", line 442, in slugify
    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
TypeError: must be unicode, not str
```

So ensure that `source` value has the correct type before passing it to `slugify`
