### PR TITLE
TranslatedAutoSlugifyMixin: fix slug uniqueness check.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.2.1 (20XX-XX-XX)
+------------------
+
+* Fix slug uniqueness check in TranslatedAutoSlugifyMixin
+
 0.2.0 (2015-10-22)
 ------------------
 

--- a/aldryn_translation_tools/models.py
+++ b/aldryn_translation_tools/models.py
@@ -175,6 +175,19 @@ class TranslatedAutoSlugifyMixin(object):
             qs = qs.exclude(pk=self.pk)
         return qs
 
+    def _slug_exists(self, slug, slug_filter=None, qs=None):
+        """
+        Check if slug exists in the given queryset.
+        If slug_filter is None it would be created from
+        self.raw_slug_filter_string and self.slug_field_name
+        """
+
+        if qs is None:
+            qs = self._get_slug_queryset()
+        if slug_filter is None:
+            slug_filter = self.raw_slug_filter_string.format(self.slug_field_name)
+        return qs.filter(**{slug_filter: slug}).exists()
+
     def make_new_slug(self, slug=None, qs=None):
         """
         Generate a slug that meets requirements.
@@ -185,20 +198,17 @@ class TranslatedAutoSlugifyMixin(object):
         :return (str): slug
         """
 
-        if qs is None:
-            qs = self._get_slug_queryset()
-        if slug is None:
+        if not slug:
             # Build the "ideal slug" for this object as a starting point
             slug = self._get_ideal_slug()
         # initial setup
         idx = 1
         candidate = slug
         max_length = self.get_slug_max_length()
-        slug_filter = self.raw_slug_filter_string.format(self.slug_field_name)
         # Check if the resulting slug is currently in use, if not, use it.
         # Otherwise, add a separator and an index until we find an
         # unused combination.
-        while qs.filter(**{slug_filter: candidate}).exists():
+        while self._slug_exists(candidate, qs=qs):
             if len(candidate) > max_length:
                 max_length = self.get_slug_max_length(len(str(idx)))
             candidate = self._get_candidate_slug(slug[:max_length], idx)
@@ -207,8 +217,8 @@ class TranslatedAutoSlugifyMixin(object):
 
     def save(self, **kwargs):
         slug = self._get_existing_slug()
-        if not slug:
-            slug = self.make_new_slug()
+        if not slug or self._slug_exists(slug):
+            slug = self.make_new_slug(slug=slug)
             setattr(self, self.slug_field_name, slug)
         return super(TranslatedAutoSlugifyMixin, self).save(**kwargs)
 

--- a/aldryn_translation_tools/models.py
+++ b/aldryn_translation_tools/models.py
@@ -185,7 +185,8 @@ class TranslatedAutoSlugifyMixin(object):
         if qs is None:
             qs = self._get_slug_queryset()
         if slug_filter is None:
-            slug_filter = self.raw_slug_filter_string.format(self.slug_field_name)
+            slug_filter = self.raw_slug_filter_string.format(
+                self.slug_field_name)
         return qs.filter(**{slug_filter: slug}).exists()
 
     def make_new_slug(self, slug=None, qs=None):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -83,6 +83,34 @@ class TestTranslatableAutoSlugifyMixin(TransactionTestCase):
 
         self.assertEquals(simple_en.slug, simple_fr.slug)
 
+    def test_slug_unique_for_language(self):
+        simple_en_1 = Simple()
+        simple_en_1.set_current_language('en')
+        simple_en_1.name = 'SimpleOne'
+        simple_en_1.save()
+        # make another instance with same name
+        simple_en_2 = Simple()
+        simple_en_2.set_current_language('en')
+        simple_en_2.name = 'SimpleOne'
+        simple_en_2.save()
+        # slugs should not be same.
+        self.assertNotEquals(simple_en_1.slug, simple_en_2.slug)
+
+    def test_slug_unique_for_language_if_slug_is_the_same(self):
+        simple_en_1 = Simple()
+        simple_en_1.set_current_language('en')
+        simple_en_1.name = 'SimpleOne'
+        simple_en_1.slug = 'simpleone'
+        simple_en_1.save()
+        # make another instance with same name
+        simple_en_2 = Simple()
+        simple_en_2.set_current_language('en')
+        simple_en_2.name = 'SimpleOne'
+        simple_en_2.slug = 'simpleone'
+        simple_en_2.save()
+        # slugs should not be same.
+        self.assertNotEquals(simple_en_1.slug, simple_en_2.slug)
+
     def test_simple_slug_default(self):
         # First test that the default works
         simple = Simple()


### PR DESCRIPTION
There was an issue with checking slug uniqueness if slug was not None (provided or has been set on the model).
This PR introduces test cases for that and the fix.
