### PR TITLE
fix: support for django 2 admin

### DIFF
--- a/aldryn_translation_tools/__init__.py
+++ b/aldryn_translation_tools/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals
 
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/aldryn_translation_tools/admin.py
+++ b/aldryn_translation_tools/admin.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-
+import django
+from distutils.version import LooseVersion
+DJANGO_2 = django.get_version() > LooseVersion('1.11')
 from django.conf import settings
 from django.forms import widgets
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext as _
+if DJANGO_2:
+    from django.utils.html import format_html
 
 from cms.utils.i18n import get_current_language
 from cms.utils.urlutils import admin_reverse
@@ -129,6 +133,8 @@ class AllTranslationsMixin(object):
                 title=title,
             )
             langs.append(link)
+        if DJANGO_2:
+            return format_html(''.join(langs))
         return ''.join(langs)
     all_translations.short_description = 'Translations'
     all_translations.allow_tags = True


### PR DESCRIPTION
As suggested in the this ticket
https://github.com/divio/aldryn-translation-tools/issues/16, the
rendering is not proper in django 2.1 and above. This fix adds support
for render in django 2.x and also keeps backward compatibility

- Github Issue: #16

Authored-by: Vinit Kumar <vinit.kumar@socialschools.nl>